### PR TITLE
fix: update alt text

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -34,7 +34,7 @@
       </a>
       {% elsif site.carpentry == "hsf" %}
       <a href="{{ site.hsf_site }}" class="pull-left">
-        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/hsf-logo.png%}" alt="The Carpentries logo" />
+        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/hsf-logo.png%}" alt="The HEP Software Foundation logo" />
       </a>
       {% endif %}
 


### PR DESCRIPTION
Update alt text for the HSF logo, in reference to hsf-training/hsf-training-scikit-hep-webpage#5.